### PR TITLE
Add workspace symbol configuration

### DIFF
--- a/data/config
+++ b/data/config
@@ -3,5 +3,5 @@ SuspendCommand: ~/.config/scripts/sys.sh suspend
 LockCommand: ~/.config/scripts/sys.sh lock
 ExitCommand: killall Hyprland
 BatteryFolder: /sys/class/power_supply/BAT1
-WorkspaceSymbol-0: 
+WorkspaceSymbol-1: 
 DefaultWorkspaceSymbol: 

--- a/data/config
+++ b/data/config
@@ -4,3 +4,4 @@ LockCommand: ~/.config/scripts/sys.sh lock
 ExitCommand: killall Hyprland
 BatteryFolder: /sys/class/power_supply/BAT1
 WorkspaceSymbol-0: 
+DefaultWorkspaceSymbol: 

--- a/data/config
+++ b/data/config
@@ -3,3 +3,4 @@ SuspendCommand: ~/.config/scripts/sys.sh suspend
 LockCommand: ~/.config/scripts/sys.sh lock
 ExitCommand: killall Hyprland
 BatteryFolder: /sys/class/power_supply/BAT1
+WorkspaceSymbol-0: 

--- a/src/Bar.cpp
+++ b/src/Bar.cpp
@@ -170,25 +170,21 @@ namespace Bar
                 {
                 case System::WorkspaceStatus::Dead:
                     workspaces[i]->SetClass("ws-dead");
-                    workspaces[i]->SetText(" ");
                     break;
                 case System::WorkspaceStatus::Inactive:
                     workspaces[i]->SetClass("ws-inactive");
-                    workspaces[i]->SetText(" ");
                     break;
                 case System::WorkspaceStatus::Visible:
                     workspaces[i]->SetClass("ws-visible");
-                    workspaces[i]->SetText(" ");
                     break;
                 case System::WorkspaceStatus::Current:
                     workspaces[i]->SetClass("ws-current");
-                    workspaces[i]->SetText(" ");
                     break;
                 case System::WorkspaceStatus::Active:
                     workspaces[i]->SetClass("ws-active");
-                    workspaces[i]->SetText(" ");
                     break;
                 }
+                workspaces[i]->SetText(System::GetWorkspaceSymbol(i));
             }
             return TimerResult::Ok;
         }

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -76,6 +76,9 @@ namespace System
             {
                 prop = &config.batteryFolder;
             }
+            else if (line.find("DefaultWorkspaceSymbol") != std::string::npos) {
+                prop = &config.defaultWorkspaceSymbol;
+            }
             else if (line.find("WorkspaceSymbol") != std::string::npos) {
                 for (int i = 0; i < 9; i++) {
                     if (line.find("WorkspaceSymbol-" + std::to_string(i)) != std::string::npos) {

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -96,18 +96,6 @@ namespace System
         }
     }
 
-    std::string GetWorkspaceSymbol(int index) {
-        if (index < 0 || index > 9) {
-            return "";
-        }
-
-        if (config.workspaceSymbols[index].empty()) {
-            return config.defaultWorkspaceSymbol + " ";
-        }
-
-        return config.workspaceSymbols[index] + " ";
-    }
-
     struct CPUTimestamp
     {
         size_t total = 0;
@@ -475,6 +463,18 @@ namespace System
     void GotoWorkspace(uint32_t workspace)
     {
         return Hyprland::Goto(workspace);
+    }
+    std::string GetWorkspaceSymbol(int index) {
+        if (index < 0 || index > 9) {
+            LOG("Workspace Symbol Index Out Of Bounds: " + std::to_string(index));
+            return "";
+        }
+
+        if (config.workspaceSymbols[index].empty()) {
+            return config.defaultWorkspaceSymbol + " ";
+        }
+
+        return config.workspaceSymbols[index] + " ";
     }
 #endif
 

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -28,7 +28,7 @@ namespace System
         std::string lockCommand = ""; // idk, no standard way of doing this.
         std::string exitCommand = ""; // idk, no standard way of doing this.
         std::string batteryFolder = ""; // this can be BAT0, BAT1, etc. Usually in /sys/class/power_supply
-        std::vector<std::string> workspaceSymbols = {"", "", "", "", "", "", "", "", ""};
+        std::vector<std::string> workspaceSymbols = std::vector<std::string>(9, "");
         std::string defaultWorkspaceSymbol = "";
     };
 

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -80,9 +80,10 @@ namespace System
                 prop = &config.defaultWorkspaceSymbol;
             }
             else if (line.find("WorkspaceSymbol") != std::string::npos) {
-                for (int i = 0; i < 9; i++) {
+                for (int i = 1; i < 10; i++) {
                     if (line.find("WorkspaceSymbol-" + std::to_string(i)) != std::string::npos) {
-                        prop = &(config.workspaceSymbols[i]);
+                        // Subtract 1 to index from 1 to 9 rather than 0 to 8
+                        prop = &(config.workspaceSymbols[i - 1]);
                     }
                 }
             }

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -28,6 +28,8 @@ namespace System
         std::string lockCommand = ""; // idk, no standard way of doing this.
         std::string exitCommand = ""; // idk, no standard way of doing this.
         std::string batteryFolder = ""; // this can be BAT0, BAT1, etc. Usually in /sys/class/power_supply
+        std::vector<std::string> workspaceSymbols = {"", "", "", "", "", "", "", "", ""};
+        std::string defaultWorkspaceSymbol = "";
     };
 
     static Config config;
@@ -74,6 +76,13 @@ namespace System
             {
                 prop = &config.batteryFolder;
             }
+            else if (line.find("WorkspaceSymbol") != std::string::npos) {
+                for (int i = 0; i < 9; i++) {
+                    if (line.find("WorkspaceSymbol-" + std::to_string(i)) != std::string::npos) {
+                        prop = &(config.workspaceSymbols[i]);
+                    }
+                }
+            }
             if (prop == nullptr)
             {
                 LOG("Warning: unknown config var: " << line);
@@ -81,6 +90,18 @@ namespace System
             }
             *prop = line.substr(line.find(' ') + 1); // Everything after space is data
         }
+    }
+
+    std::string GetWorkspaceSymbol(int index) {
+        if (index < 0 || index > 9) {
+            return "";
+        }
+
+        if (config.workspaceSymbols[index].empty()) {
+            return config.defaultWorkspaceSymbol + " ";
+        }
+
+        return config.workspaceSymbols[index] + " ";
     }
 
     struct CPUTimestamp

--- a/src/System.h
+++ b/src/System.h
@@ -5,8 +5,6 @@
 
 namespace System
 {
-    std::string GetWorkspaceSymbol(int index);
-
     // From 0-1, all cores
     double GetCPUUsage();
     // Tctl
@@ -92,6 +90,7 @@ namespace System
     };
     WorkspaceStatus GetWorkspaceStatus(uint32_t monitor, uint32_t workspace);
     void GotoWorkspace(uint32_t workspace);
+    std::string GetWorkspaceSymbol(int index);
 #endif
 
     std::string GetTime();

--- a/src/System.h
+++ b/src/System.h
@@ -5,6 +5,8 @@
 
 namespace System
 {
+    std::string GetWorkspaceSymbol(int index);
+
     // From 0-1, all cores
     double GetCPUUsage();
     // Tctl


### PR DESCRIPTION
Added the ability to configure the symbols of the workspaces in the .config. The syntax is:
```
WorkspaceSymbol-[Workspace Index]: [Symbol]
```
For example, to change the third workspace to be "3":
```
WorkspaceSymbol-3: 3
```
This indexes from 1, but I can easily change that if you prefer indexing from 0. 

I also added a default workspace symbol option, which is used when no workspace symbol is provided. If no default is provided, then the circle with dot symbol is used. The syntax for changing the default is:
```
DefaultWorkspaceSymbol: [Symbol]
```
The default and a workspace symbol change has been added to the config at data/config.