### PR TITLE
Nix: fix invalid default value and extend documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,30 @@ You can install it e.g.: with yay
 If you choose the Nix/NixOS installation there are a couple of ways to do it but they all require you to have flakes enabled.
 - Building it seperately and just running the binary, run nix build in the directory and use the binary from ./result/bin
 - Import the flake to inputs and then add `gBar.defaultPackage.x86_64-linux` to either environment.systemPackages or home.packages.
-- Use the home manager module. This is done by, as in the previous way, importing the flake and then adding `gBar.homeManagerModules.x86_64-linux.default` into your home-manager imorts section. This exposes the option programs.gBar to home manager and you can look at the module file to see available options, but in short under `programs.gBar.config` you can put all options from the standard configs names (some exceptions) in there and it works like expected, some options have a refined configuration syntax.
+- Use the home manager module. This is done by, as in the previous way, importing the flake and then adding `gBar.homeManagerModules.x86_64-linux.default` into your home-manager imorts section. This exposes the option programs.gBar to home-manager, use it like below.
+```nix
+# Inputs section
+inputs.gBar.url = "github:scorpion-26/gBar";
+...
+# Inside home config
+home-manager.users.user = {
+    ...
+    imports = [ inputs.gBar.homeManagerModules.x86_64-linux.default ];
+    ...
+    programs.gBar = {
+        enable = true;
+        config = {
+            Location = "L";
+            EnableSNI = true;
+            SNIIconSize = {
+                Discord = 26;
+                OBS = 23;
+            };
+            WorkspaceSymbols = [ " " " " ];
+        };
+    };
+};
+```
 
 ## Running gBar
 *Open bar on monitor 0*

--- a/module.nix
+++ b/module.nix
@@ -115,7 +115,7 @@ in {
                 };
                 DateTimeStyle = mkOption {
                     type = types.nullOr types.str;
-                    default = "";
+                    default = "%a %D - %H:%M:%S %Z";
                     description = "Set datetime style";
                 };
                 AudioInput = mkOption {
@@ -159,12 +159,12 @@ in {
                     description = "Enable tray icons";
                 };
                 SNIIconSize = mkOption {
-                    type = types.nullOr (types.attrsOf types.int);
+                    type = types.attrsOf types.int;
                     default = {};
                     description = "sets the icon size for a SNI icon, an attribute set where, for example you can put Discord = 23 as an attribute and thus make discord slightly smaller Set to * to apply to all";
                 };
                 SNIIconPaddingTop = mkOption {
-                    type = types.nullOr (types.attrsOf types.int);
+                    type = types.attrsOf types.int;
                     default = {};
                     description = "Can be used to push the Icon down. Negative values are allowed same as IconSize with an attribute set";
                 };


### PR DESCRIPTION
Previous default value of date creates null option in gBar config and crashed the bar, removes null as accepted option in SNIIcon* options as that also crashes the bar. I also felt like documentation lacked so wrote this.