### PR TITLE
Bug Fix: NixOS Missing Semicolon in `module.nix`

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -136,7 +136,7 @@ in {
                 AudioNumbers = mkOption {
                     type = types.bool;
                     default = false;
-                    description = "Display numbers instead of a slider for the two audio widgets. Doesn't affect the audio flyin"
+                    description = "Display numbers instead of a slider for the two audio widgets. Doesn't affect the audio flyin";
                 };
                 AudioMinVolume = mkOption {
                     type = types.nullOr types.int;


### PR DESCRIPTION
Nix build was broken due to a missing semicolon.