### PR TITLE
make locale of DateTime widget configurable

### DIFF
--- a/data/config
+++ b/data/config
@@ -60,6 +60,9 @@ TimeSpace: 300
 # Set datetime style
 # DateTimeStyle: %a %D - %H:%M:%S %Z
 
+# Set datetime locale (defaults to system locale if not set or set to empty string)
+# DateTimeLocale: de_DE.utf8
+
 # Adds a audio input(aka. microphone) widget
 AudioInput: false
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -177,6 +177,7 @@ void Config::Load()
         AddConfigVar("BatteryFolder", config.batteryFolder, lineView, foundProperty);
         AddConfigVar("DefaultWorkspaceSymbol", config.defaultWorkspaceSymbol, lineView, foundProperty);
         AddConfigVar("DateTimeStyle", config.dateTimeStyle, lineView, foundProperty);
+        AddConfigVar("DateTimeLocale", config.dateTimeLocale, lineView, foundProperty);
         AddConfigVar("CheckPackagesCommand", config.checkPackagesCommand, lineView, foundProperty);
         for (int i = 1; i < 10; i++)
         {
@@ -202,7 +203,6 @@ void Config::Load()
         AddConfigVar("CheckUpdateInterval", config.checkUpdateInterval, lineView, foundProperty);
 
         AddConfigVar("TimeSpace", config.timeSpace, lineView, foundProperty);
-        AddConfigVar("DateTimeLocale", config.dateTimeLocale, lineView, foundProperty);
 
         AddConfigVar("AudioScrollSpeed", config.audioScrollSpeed, lineView, foundProperty);
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -202,6 +202,7 @@ void Config::Load()
         AddConfigVar("CheckUpdateInterval", config.checkUpdateInterval, lineView, foundProperty);
 
         AddConfigVar("TimeSpace", config.timeSpace, lineView, foundProperty);
+        AddConfigVar("DateTimeLocale", config.dateTimeLocale, lineView, foundProperty);
 
         AddConfigVar("AudioScrollSpeed", config.audioScrollSpeed, lineView, foundProperty);
 

--- a/src/Config.h
+++ b/src/Config.h
@@ -16,6 +16,7 @@ public:
     std::vector<std::string> workspaceSymbols = std::vector<std::string>(9, "");
     std::string defaultWorkspaceSymbol = "";
     std::string dateTimeStyle = "%a %D - %H:%M:%S %Z"; // A sane default
+    std::string dateTimeLocale = ""; // use system locale
 
     // Script that returns how many packages are out-of-date. The script should only print a number!
     // See data/update.sh for a human-readable version

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -605,6 +605,7 @@ namespace System
         time_t stdTime = time(NULL);
         tm* localTime = localtime(&stdTime);
         std::stringstream str;
+        str.imbue(std::locale(Config::Get().dateTimeLocale.c_str()));
         str << std::put_time(localTime, Config::Get().dateTimeStyle.c_str());
         return str.str();
     }


### PR DESCRIPTION
This makes the `DateTimeStyle` string respect the current locale or whatever valid locale is set via configuration option `DateTimeLocale`. 
![2023-08-31-233240_hyprshot](https://github.com/scorpion-26/gBar/assets/3963703/f83a41ef-5b67-4857-b861-4e2fef056d55)
![2023-08-31-233439_hyprshot](https://github.com/scorpion-26/gBar/assets/3963703/ab41073e-e771-435f-bd4c-56757e611a64)
