### PR TITLE
Make the partition monitored by disk sensor configurable

### DIFF
--- a/data/config
+++ b/data/config
@@ -22,7 +22,7 @@ ExitCommand: killall Hyprland
 # The folder, where the battery sensors reside
 BatteryFolder: /sys/class/power_supply/BAT1
 
-# The partion to monitor with disk sensor
+# The partition to monitor with disk sensor
 DiskPartition: /
 
 # Overrides the icon of the nth (in this case the first) workspace.

--- a/data/config
+++ b/data/config
@@ -22,6 +22,9 @@ ExitCommand: killall Hyprland
 # The folder, where the battery sensors reside
 BatteryFolder: /sys/class/power_supply/BAT1
 
+# The partion to monitor in disk sensor (default to "/")
+# DiskPartition: /home
+
 # Overrides the icon of the nth (in this case the first) workspace.
 # Please note the missing space between "," and the symbol. Adding a space here adds it to the bar too!
 #WorkspaceSymbol: 1,

--- a/data/config
+++ b/data/config
@@ -22,8 +22,8 @@ ExitCommand: killall Hyprland
 # The folder, where the battery sensors reside
 BatteryFolder: /sys/class/power_supply/BAT1
 
-# The partion to monitor in disk sensor (default to "/")
-# DiskPartition: /home
+# The partion to monitor with disk sensor
+DiskPartition: /
 
 # Overrides the icon of the nth (in this case the first) workspace.
 # Please note the missing space between "," and the symbol. Adding a space here adds it to the bar too!
@@ -67,10 +67,10 @@ CenterTime: true
 TimeSpace: 300
 
 # Set datetime style
-# DateTimeStyle: %a %D - %H:%M:%S %Z
+DateTimeStyle: %a %D - %H:%M:%S %Z
 
 # Set datetime locale (defaults to system locale if not set or set to empty string)
-# DateTimeLocale: de_DE.utf8
+#DateTimeLocale: de_DE.utf8
 
 # Adds a audio input(aka. microphone) widget
 AudioInput: false
@@ -115,11 +115,11 @@ EnableSNI: true
 # For both: The first parameter is a filter of the tooltip(The text that pops up, when the icon is hovered) of the icon
 
 # Scale everything down to 25 pixels ('*' as filter means everything)
-SNIIconSize: *, 25
+#SNIIconSize: *, 25
 # Explicitly make OBS a bit smaller than default
-SNIIconSize: OBS, 23
+#SNIIconSize: OBS, 23
 # Nudges the Discord icon a bit down
-# SNIPaddingTop: Discord, 5
+#SNIPaddingTop: Discord, 5
 
 # These set the range for the network widget. The widget changes colors at six intervals:
 #    - Below Min...Bytes ("under")

--- a/module.nix
+++ b/module.nix
@@ -58,6 +58,11 @@ in {
                     default = "/sys/class/power_supply/BAT1";
                     description = "The folder, where the battery sensors reside";
                 };
+                DiskPartition = mkOption {
+                    type = types.str;
+                    default = "/";
+                    description = "The partition to monitor with disk sensor";
+                };
                 WorkspaceSymbols = mkOption {
                     type = types.nullOr (types.listOf types.str);
                     default = [];

--- a/src/Bar.cpp
+++ b/src/Bar.cpp
@@ -124,7 +124,7 @@ namespace Bar
         {
             System::DiskInfo info = System::GetDiskInfo();
 
-            std::string text = "Disk: " + Utils::ToStringPrecision(info.usedGiB, "%0.2f") + "GiB/" +
+            std::string text = "Disk " + info.partition + ": " + Utils::ToStringPrecision(info.usedGiB, "%0.2f") + "GiB/" +
                                Utils::ToStringPrecision(info.totalGiB, "%0.2f") + "GiB";
             if (Config::Get().sensorTooltips)
             {

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -201,6 +201,7 @@ void Config::Load()
         AddConfigVar("DateTimeStyle", config.dateTimeStyle, lineView, foundProperty);
         AddConfigVar("DateTimeLocale", config.dateTimeLocale, lineView, foundProperty);
         AddConfigVar("CheckPackagesCommand", config.checkPackagesCommand, lineView, foundProperty);
+        AddConfigVar("DiskPartition", config.diskPartition, lineView, foundProperty);
 
         AddConfigVar("CenterTime", config.centerTime, lineView, foundProperty);
         AddConfigVar("AudioInput", config.audioInput, lineView, foundProperty);

--- a/src/Config.h
+++ b/src/Config.h
@@ -18,6 +18,7 @@ public:
     std::string defaultWorkspaceSymbol = "";
     std::string dateTimeStyle = "%a %D - %H:%M:%S %Z"; // A sane default
     std::string dateTimeLocale = "";                   // use system locale
+    std::string diskPartition = "/";                   // should be expectable on every linux system
 
     // Script that returns how many packages are out-of-date. The script should only print a number!
     // See data/update.sh for a human-readable version

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -202,11 +202,12 @@ namespace System
     DiskInfo GetDiskInfo()
     {
         struct statvfs stat;
-        int err = statvfs(Config::Get().diskPartition.c_str(), &stat);
-        ASSERT(err == 0, "Cannot stat diskPartition!");
+        std::string partition = Config::Get().diskPartition;
+        int err = statvfs(partition.c_str(), &stat);
+        ASSERT(err == 0, "Cannot stat " + partition + "!");
 
         DiskInfo out{};
-        out.partition = Config::Get().diskPartition;
+        out.partition = partition;
         out.totalGiB = (double)(stat.f_blocks * stat.f_frsize) / (1024 * 1024 * 1024);
         out.usedGiB = (double)((stat.f_blocks - stat.f_bfree) * stat.f_frsize) / (1024 * 1024 * 1024);
         return out;

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -202,10 +202,11 @@ namespace System
     DiskInfo GetDiskInfo()
     {
         struct statvfs stat;
-        int err = statvfs("/", &stat);
-        ASSERT(err == 0, "Cannot stat root!");
+        int err = statvfs(Config::Get().diskPartition.c_str(), &stat);
+        ASSERT(err == 0, "Cannot stat diskPartition!");
 
         DiskInfo out{};
+        out.partition = Config::Get().diskPartition;
         out.totalGiB = (double)(stat.f_blocks * stat.f_frsize) / (1024 * 1024 * 1024);
         out.usedGiB = (double)((stat.f_blocks - stat.f_bfree) * stat.f_frsize) / (1024 * 1024 * 1024);
         return out;

--- a/src/System.h
+++ b/src/System.h
@@ -38,6 +38,7 @@ namespace System
 
     struct DiskInfo
     {
+        std::string partition;
         double totalGiB;
         double usedGiB;
     };


### PR DESCRIPTION
I needed a way to monitor another partition than "/", which is nearly empty on my system. Might be improvable by verifying  that the given string is a partition indeed. For the moment this should be as safe as _statvfs_ is :)