### PR TITLE
 Nix: Add missing option for NumWorkspaces and remove bad default nulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,30 @@ You can install it e.g.: with yay
 If you choose the Nix/NixOS installation there are a couple of ways to do it but they all require you to have flakes enabled.
 - Building it seperately and just running the binary, run nix build in the directory and use the binary from ./result/bin
 - Import the flake to inputs and then add `gBar.defaultPackage.x86_64-linux` to either environment.systemPackages or home.packages.
-- Use the home manager module. This is done by, as in the previous way, importing the flake and then adding `gBar.homeManagerModules.x86_64-linux.default` into your home-manager imorts section. This exposes the option programs.gBar to home manager and you can look at the module file to see available options, but in short under `programs.gBar.config` you can put all options from the standard configs names (some exceptions) in there and it works like expected, some options have a refined configuration syntax.
+- Use the home manager module. This is done by, as in the previous way, importing the flake and then adding `gBar.homeManagerModules.x86_64-linux.default` into your home-manager imorts section. This exposes the option programs.gBar to home-manager, use it like below.
+```nix
+# Inputs section
+inputs.gBar.url = "github:scorpion-26/gBar";
+...
+# Inside home config
+home-manager.users.user = {
+    ...
+    imports = [ inputs.gBar.homeManagerModules.x86_64-linux.default ];
+    ...
+    programs.gBar = {
+        enable = true;
+        config = {
+            Location = "L";
+            EnableSNI = true;
+            SNIIconSize = {
+                Discord = 26;
+                OBS = 23;
+            };
+            WorkspaceSymbols = [ " " " " ];
+        };
+    };
+};
+```
 
 ## Running gBar
 *Open bar on monitor 0*

--- a/module.nix
+++ b/module.nix
@@ -115,7 +115,7 @@ in {
                 };
                 DateTimeStyle = mkOption {
                     type = types.nullOr types.str;
-                    default = "";
+                    default = "%a %D - %H:%M:%S %Z";
                     description = "Set datetime style";
                 };
                 AudioInput = mkOption {
@@ -159,12 +159,12 @@ in {
                     description = "Enable tray icons";
                 };
                 SNIIconSize = mkOption {
-                    type = types.nullOr (types.attrsOf types.int);
+                    type = types.attrsOf types.int;
                     default = {};
                     description = "sets the icon size for a SNI icon, an attribute set where, for example you can put Discord = 23 as an attribute and thus make discord slightly smaller Set to * to apply to all";
                 };
                 SNIIconPaddingTop = mkOption {
-                    type = types.nullOr (types.attrsOf types.int);
+                    type = types.attrsOf types.int;
                     default = {};
                     description = "Can be used to push the Icon down. Negative values are allowed same as IconSize with an attribute set";
                 };

--- a/module.nix
+++ b/module.nix
@@ -65,13 +65,18 @@ in {
                 };
                 WorkspaceSymbols = mkOption {
                     type = types.nullOr (types.listOf types.str);
-                    default = [];
+                    default = null;
                     description = "A list of strings where the position in the list is the icon to change, overrides the default symbol";
                 };
                 DefaultWorkspaceSymbol = mkOption {
                     type = types.str;
                     default = "";
                     description = "The default symbol for the workspaces";
+                };
+                NumWorkspaces = mkOption {
+                    type = types.int;
+                    default = 9;
+                    description = "Number of workspaces to display. Displayed workspace IDs are 1-n (Default: 1-9)";
                 };
                 WorkspaceScrollOnMonitor = mkOption {
                     type = types.bool;
@@ -85,7 +90,7 @@ in {
                 };
                 UseHyprlandIPC = mkOption {
                     type = types.bool;
-                    default = false;
+                    default = true;
                     description = ''
                         Use Hyprland IPC instead of the ext_workspace protocol for workspace polling.
                         Hyprland IPC is *slightly* less performant (+0.1% one core), but way less bug prone,
@@ -119,7 +124,7 @@ in {
                     '';
                 };
                 DateTimeStyle = mkOption {
-                    type = types.nullOr types.str;
+                    type = types.str;
                     default = "%a %D - %H:%M:%S %Z";
                     description = "Set datetime style";
                 };
@@ -139,7 +144,7 @@ in {
                     description = "Sets the audio slider to be on reveal (Just like the sensors) when true. Only affects the bar.";
                 };
                 AudioScrollSpeed = mkOption {
-                    type = types.nullOr types.int;
+                    type = types.int;
                     default = 5;
                     description = "Sets the rate of change of the slider on each scroll. In Percent";
                 };
@@ -149,17 +154,17 @@ in {
                     description = "Display numbers instead of a slider for the two audio widgets. Doesn't affect the audio flyin";
                 };
                 AudioMinVolume = mkOption {
-                    type = types.nullOr types.int;
+                    type = types.int;
                     default = 0;
                     description = "Limits the range of the audio slider. Only works for audio output. Slider 'empty' is AudioMinVolume, Slider 'full' is AudioMaxVolume";
                 };
                 AudioMaxVolume = mkOption {
-                    type = types.nullOr types.int;
+                    type = types.int;
                     default = 100;
                     description = "";
                 };
                 NetworkAdapter = mkOption {
-                    type = types.nullOr types.str;
+                    type = types.str;
                     default = "eno1";
                     description = "The network adapter to use. You can query /sys/class/net for all possible values";
                 };
@@ -196,22 +201,22 @@ in {
                 #    - Between ]75%;100%]. 0% = Min...Bytes; 100% = Max...Bytes ("high")
                 #    - Above Max...Bytes ("over")
                 MinDownloadBytes = mkOption {
-                    type = types.nullOr types.int;
+                    type = types.int;
                     default = 0;
                     description = "";
                 };
                 MaxDownloadBytes = mkOption {
-                    type = types.nullOr types.int;
+                    type = types.int;
                     default = 10485760;
                     description = "";
                 };
                 MinUploadBytes = mkOption {
-                    type = types.nullOr types.int;
+                    type = types.int;
                     default = 0;
                     description = "";
                 };
                 MaxUploadBytes = mkOption {
-                    type = types.nullOr types.int;
+                    type = types.int;
                     default = 5242880;
                     description = "";
                 };


### PR DESCRIPTION
No option for NumWorkspaces and some options could be null while they shouldn't. Also set UseHyprlandIPC to true by default as that is now required by Hyprland 0.30.