### PR TITLE
fix: replace hard-coded paths with envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ The colors are from the Dracula theme: https://draculatheme.com
 
 ### I want to customize the colors
 First, find where the data is located for gBar. Possible locations: 
+ - In a 'gBar' directory found in any of the directories listed by `echo $XDG_DATA_DIRS`
  - /usr/share/gBar
  - /usr/local/share/gBar
  - ~/.local/share/gBar

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1689068808,
-        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689752456,
-        "narHash": "sha256-VOChdECcEI8ixz8QY+YC4JaNEFwQd1V8bA0G4B28Ki0=",
+        "lastModified": 1701040486,
+        "narHash": "sha256-vawYwoHA5CwvjfqaT3A5CT9V36Eq43gxdwpux32Qkjw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7f256d7da238cb627ef189d56ed590739f42f13b",
+        "rev": "45827faa2132b8eade424f6bdd48d8828754341a",
         "type": "github"
       },
       "original": {

--- a/src/CSS.cpp
+++ b/src/CSS.cpp
@@ -15,31 +15,31 @@ namespace CSS
 
         std::vector<std::string> locations;
         const char* home = std::getenv("HOME");
-        const char* env;
 
-        if ((env = std::getenv("XDG_CONFIG_HOME")) && strlen(env))
+        const char* configHome = std::getenv("XDG_CONFIG_HOME");
+        if (configHome && strlen(configHome) != 0)
         {
-            locations.push_back(env);
+            locations.push_back(configHome);
         }
         else if (home)
         {
-            std::string s(home);
-            locations.push_back(s + "/.config");
+            locations.push_back(std::string(home) + "/.config");
         }
 
-        if ((env = std::getenv("XDG_DATA_HOME")) && strlen(env))
+        const char* dataHome = std::getenv("XDG_DATA_HOME");
+        if (dataHome && strlen(dataHome) != 0)
         {
-            locations.push_back(env);
+            locations.push_back(dataHome);
         }
         else if (home)
         {
-            std::string s(home);
-            locations.push_back(s + "/.local/share");
+            locations.push_back(std::string(home) + "/.local/share");
         }
 
-        if ((env = std::getenv("XDG_DATA_DIRS")))
+        const char* dataDirs = std::getenv("XDG_DATA_DIRS");
+        if (dataDirs && strlen(dataDirs) != 0)
         {
-            std::stringstream ss(env);
+            std::stringstream ss(dataDirs);
             std::string dir;
             while (std::getline(ss, dir, ':'))
                 locations.push_back(dir);

--- a/src/CSS.cpp
+++ b/src/CSS.cpp
@@ -13,36 +13,51 @@ namespace CSS
     {
         sProvider = gtk_css_provider_new();
 
-        struct CSSDir
+        std::vector<std::string> locations;
+        const char* home = std::getenv("HOME");
+        const char* env;
+
+        if ((env = std::getenv("XDG_CONFIG_HOME")) && strlen(env))
         {
-            std::string xdgEnv;
-            std::string fallbackPath;
-            std::string relPath;
-        };
-        std::string home = getenv("HOME");
-        std::array<CSSDir, 4> locations = {
-            CSSDir{"XDG_CONFIG_HOME", home + "/.config",      "/gBar/style.css"}, // Local config
-            CSSDir{"XDG_DATA_HOME",   home + "/.local/share", "/gBar/style.css"}, // local user install
-            CSSDir{"",                "/usr/local/share",     "/gBar/style.css"}, // local all install
-            CSSDir{"",                "/usr/share",           "/gBar/style.css"}, // package manager all install
-        };
+            locations.push_back(env);
+        }
+        else if (home)
+        {
+            std::string s(home);
+            locations.push_back(s + "/.config");
+        }
+
+        if ((env = std::getenv("XDG_DATA_HOME")) && strlen(env))
+        {
+            locations.push_back(env);
+        }
+        else if (home)
+        {
+            std::string s(home);
+            locations.push_back(s + "/.local/share");
+        }
+
+        if ((env = std::getenv("XDG_DATA_DIRS")))
+        {
+            std::stringstream ss(env);
+            std::string dir;
+            while (std::getline(ss, dir, ':'))
+                locations.push_back(dir);
+        }
+        else
+        {
+            locations.push_back("/usr/local/share");
+            locations.push_back("/usr/share");
+        }
 
         GError* err = nullptr;
         for (auto& dir : locations)
         {
-            const char* xdgConfig = dir.xdgEnv.size() ? getenv(dir.xdgEnv.c_str()) : nullptr;
-            std::string file;
-            if (xdgConfig)
-            {
-                file = (std::string(xdgConfig) + dir.relPath).c_str();
-            }
-            else
-            {
-                file = (dir.fallbackPath + dir.relPath).c_str();
-            }
+            std::string file = dir + "/gBar/style.css";
+
             if (!std::ifstream(file).is_open())
             {
-                LOG("Info: No CSS found in " << dir.fallbackPath);
+                LOG("Info: No CSS found in " << dir);
                 continue;
             }
 
@@ -53,7 +68,7 @@ namespace CSS
                 LOG("CSS found and loaded successfully!");
                 return;
             }
-            LOG("Warning: Failed loading config for " << dir.fallbackPath << ", trying next one!");
+            LOG("Warning: Failed loading config for " << dir << ", trying next one!");
             // Log any errors
             LOG(err->message);
             g_error_free(err);


### PR DESCRIPTION
According to XDG specifications paths like /usr/share etc. are usually in XDG_DATA_DIRS. Since this variable may be set differently for other linux distributions we prefer those environment variables to hard-coded paths. As such hard-coded paths have been removed

This solves issue #66