### PR TITLE
Add CSS classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build
 compile_commands.json
 result
+.idea

--- a/css/style.css
+++ b/css/style.css
@@ -30,6 +30,11 @@
   color: #6272a4;
 }
 
+.lock-button {
+  font-size: 28px;
+  color: #6272a4;
+}
+
 .exit-button {
   font-size: 28px;
   color: #6272a4;

--- a/css/style.css
+++ b/css/style.css
@@ -135,66 +135,35 @@ highlight {
   color: #1793D1;
 }
 
-.disk-util-progress {
+.disk-widget * {
   color: #bd93f9;
   background-color: #44475a;
   font-size: 16px;
 }
 
-.disk-data-text {
-  color: #bd93f9;
-  font-size: 16px;
-}
-
-.vram-util-progress {
+.vram-widget * {
   color: #ffb86c;
   background-color: #44475a;
 }
 
-.vram-data-text {
-  color: #ffb86c;
-  font-size: 16px;
-}
-
-.ram-util-progress {
+.ram-widget * {
   color: #f1fa8c;
   background-color: #44475a;
 }
 
-.ram-data-text {
-  color: #f1fa8c;
-  font-size: 16px;
-}
-
-.gpu-util-progress {
+.gpu-widget * {
   color: #8be9fd;
   background-color: #44475a;
 }
 
-.gpu-data-text {
-  color: #8be9fd;
-  font-size: 16px;
-}
-
-.cpu-util-progress {
+.cpu-widget * {
   color: #50fa7b;
   background-color: #44475a;
-  font-size: 16px;
 }
 
-.cpu-data-text {
-  color: #50fa7b;
-  font-size: 16px;
-}
-
-.battery-util-progress {
+.battery-widget * {
   color: #ff79c6;
   background-color: #44475a;
-  font-size: 16px;
-}
-
-.battery-data-text {
-  color: #ff79c6;
   font-size: 16px;
 }
 
@@ -384,5 +353,3 @@ highlight {
   animation-timing-function: linear;
   animation-fill-mode: forwards;
 }
-
-/*# sourceMappingURL=style.css.map */

--- a/css/style.scss
+++ b/css/style.scss
@@ -55,6 +55,11 @@ $textsize: 16px;
 
     color: $darkblue;
 }
+.lock-button {
+    font-size: 28px;
+
+    color: $darkblue;
+}
 .exit-button {
     font-size: 28px;
 

--- a/css/style.scss
+++ b/css/style.scss
@@ -177,61 +177,35 @@ highlight {
     color: $btblue;
 }
 
-.disk-util-progress {
+.disk-widget * {
     color: $purple;
     background-color: $inactive;
     font-size: $textsize;
 }
-.disk-data-text {
-    color: $purple;
-    font-size: $textsize;
-}
 
-.vram-util-progress {
+.vram-widget * {
     color: $orange;
     background-color: $inactive;
 }
-.vram-data-text {
-    color: $orange;
-    font-size: $textsize;
-}
 
-.ram-util-progress {
+.ram-widget * {
     color: $yellow;
     background-color: $inactive;
 }
-.ram-data-text {
-    color: $yellow;
-    font-size: $textsize;
-}
 
-.gpu-util-progress {
+.gpu-widget * {
     color: $cyan;
     background-color: $inactive;
 }
-.gpu-data-text {
-    color: $cyan;
-    font-size: $textsize;
-}
 
-.cpu-util-progress {
+.cpu-widget * {
     color: $green;
     background-color: $inactive;
-    font-size: $textsize;
-}
-.cpu-data-text {
-    color: $green;
-    font-size: $textsize;
 }
 
-.battery-util-progress {
+.battery-widget * {
     color: $pink;
     background-color: $inactive;
-    font-size: $textsize;
-}
-
-.battery-data-text {
-    color: $pink;
     font-size: $textsize;
 }
 

--- a/src/Bar.cpp
+++ b/src/Bar.cpp
@@ -562,6 +562,17 @@ namespace Bar
         {
             auto box = Widget::Create<Box>();
             box->SetSpacing({8, false});
+            box->AddClass("widget");
+            switch (type)
+            {
+            case AudioType::Input:
+                box->AddClass("mic");
+                break;
+            case AudioType::Output:
+                box->AddClass("audio");
+                break;
+            }
+
             Utils::SetTransform(*box, {-1, false, SideToAlignment(side)});
             box->SetOrientation(Utils::GetOrientation());
             {
@@ -643,6 +654,7 @@ namespace Bar
         text->SetText("");
         text->SetVisible(false);
         text->SetClass("package-empty");
+        text->AddClass("widget");
         text->SetAngle(Utils::GetAngle());
         text->AddTimer<Text>(DynCtx::UpdatePackages, 1000 * Config::Get().checkUpdateInterval, TimerDispatchBehaviour::ImmediateDispatch);
 
@@ -660,6 +672,8 @@ namespace Bar
     {
         auto box = Widget::Create<Box>();
         box->SetSpacing({0, false});
+        box->AddClass("widget");
+        box->AddClass("bluetooth");
         box->SetOrientation(Utils::GetOrientation());
         Utils::SetTransform(*box, {-1, false, SideToAlignment(side)});
         {
@@ -723,6 +737,8 @@ namespace Bar
         {
             auto box = Widget::Create<Box>();
             box->SetSpacing({0, false});
+            box->AddClass("widget");
+            box->AddClass("network");
             box->SetOrientation(Utils::GetOrientation());
             {
                 auto revealer = Widget::Create<Revealer>();
@@ -834,6 +850,7 @@ namespace Bar
         {
             auto powerBox = Widget::Create<Box>();
             powerBox->SetClass("power-box");
+            powerBox->AddClass("widget");
             powerBox->SetSpacing({0, false});
             powerBox->SetOrientation(Utils::GetOrientation());
             {
@@ -874,7 +891,7 @@ namespace Bar
                             });
 
                         auto lockButton = Widget::Create<Button>();
-                        lockButton->SetClass("sleep-button");
+                        lockButton->SetClass("lock-button");
                         lockButton->SetText(Config::Get().lockIcon);
                         lockButton->SetAngle(Utils::GetAngle());
                         if (RotatedIcons())
@@ -1011,6 +1028,8 @@ namespace Bar
         {
             auto box = Widget::Create<Box>();
             box->SetSpacing({8, true});
+            box->AddClass("workspaces");
+            box->AddClass("widget");
             box->SetOrientation(Utils::GetOrientation());
             {
                 DynCtx::workspaces.resize(Config::Get().numWorkspaces);
@@ -1039,7 +1058,8 @@ namespace Bar
         auto time = Widget::Create<Text>();
         Utils::SetTransform(*time, {-1, false, SideToAlignment(side)});
         time->SetAngle(Utils::GetAngle());
-        time->SetClass("time-text");
+        time->SetClass("widget");
+        time->AddClass("time-text");
         time->SetText("Uninitialized");
         time->AddTimer<Text>(DynCtx::UpdateTime, 1000);
         parent.AddChild(std::move(time));
@@ -1171,6 +1191,7 @@ namespace Bar
 
             auto left = Widget::Create<Box>();
             left->SetSpacing({6, false});
+            left->SetClass("left");
             left->SetOrientation(Utils::GetOrientation());
             // For centerTime the width of the left widget handles the centering.
             // For not centerTime we want to set it as much right as possible. So let this expand as much as possible.
@@ -1182,6 +1203,7 @@ namespace Bar
             }
 
             auto center = Widget::Create<Box>();
+            center->SetClass("center");
             center->SetOrientation(Utils::GetOrientation());
             Utils::SetTransform(*center, {(int)Config::Get().timeSpace, false, Alignment::Left});
             center->SetSpacing({6, false});

--- a/src/SNI.cpp
+++ b/src/SNI.cpp
@@ -562,6 +562,8 @@ namespace SNI
         }
         // Add parent box
         auto box = Widget::Create<Box>();
+        box->AddClass("widget");
+        box->AddClass("sni");
         Utils::SetTransform(*box, {-1, false, Alignment::Fill});
         auto container = Widget::Create<Box>();
         container->AddTimer<Box>(UpdateWidgets, 1000, TimerDispatchBehaviour::LateDispatch);


### PR DESCRIPTION
This PR adds classes to every widget. 

Introduces a breaking change for the lock-button, which needs to be added to the style.css manually if you're using a custom one.

Every widget gets a "widget" class as well as a specific one like an id. 
In the future, names/ids should be used for that.
Also cleaned up the sensors a little as well as the related CSS.

Fixes #70.

LMK if there's anything I forgot.