### PR TITLE
allow configuring the bar through scss directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ My personal blazingly fast and efficient status bar + widgets, in case anyone fi
 - gtk-layer-shell
 - PulseAudio server (PipeWire works too!)
 - pamixer
+- libsass
 - meson, gcc/clang, ninja
 
 ## Building and installation (Manually)

--- a/meson.build
+++ b/meson.build
@@ -28,10 +28,7 @@ gtk_layer_shell = dependency('gtk-layer-shell-0')
 
 pulse = dependency('libpulse')
 
-
-comp = meson.get_compiler('cpp')
-
-sass_lib = comp.find_library('libsass')
+sass = dependency('libsass')
 
 
 headers = [
@@ -64,7 +61,7 @@ sources = [
    'src/SNI.cpp',
    ]
 
-dependencies = [gtk, gtk_layer_shell, pulse, wayland_client, sass_lib]
+dependencies = [gtk, gtk_layer_shell, pulse, wayland_client, sass]
 
 if get_option('WithHyprland')
   add_global_arguments('-DWITH_HYPRLAND', language: 'cpp')

--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,12 @@ gtk_layer_shell = dependency('gtk-layer-shell-0')
 
 pulse = dependency('libpulse')
 
+
+comp = meson.get_compiler('cpp')
+
+sass_lib = comp.find_library('libsass')
+
+
 headers = [
   'src/Common.h',
   'src/Log.h',
@@ -58,7 +64,7 @@ sources = [
    'src/SNI.cpp',
    ]
 
-dependencies = [gtk, gtk_layer_shell, pulse, wayland_client ]
+dependencies = [gtk, gtk_layer_shell, pulse, wayland_client, sass_lib]
 
 if get_option('WithHyprland')
   add_global_arguments('-DWITH_HYPRLAND', language: 'cpp')

--- a/src/CSS.cpp
+++ b/src/CSS.cpp
@@ -68,13 +68,13 @@ namespace CSS
                 Sass_File_Context* ctx =  sass_make_file_context(file.c_str());
                 Sass_Context* ctxout = sass_file_context_get_context(ctx);
                 sass_compile_file_context(ctx);
-                std::string data = sass_context_get_output_string(ctxout);
                 if(sass_context_get_error_status(ctxout))
                 {
                     LOG("Error Compiling SCSS: " << sass_context_get_error_message(ctxout));
                 }
                 else
                 {
+                    std::string data = sass_context_get_output_string(ctxout);
                     gtk_css_provider_load_from_data(sProvider, data.c_str(), data.length(), &err);
                     scss_suceeded = true;
                 }


### PR DESCRIPTION
after looking at the source code it is my impression, that even though an scss file is present this needs to be converted manually and only the CSS file is parsed. This pull request sets out to fix that.

there is preliminary scss support using libsass now (yes I know that libsass is technically "deprecated" but I was unable to find any other c/c++ library for converting scss to css)