### PR TITLE
Consider transform when calculating monitor size

### DIFF
--- a/src/Wayland.cpp
+++ b/src/Wayland.cpp
@@ -179,7 +179,25 @@ namespace Wayland
 
     // Output Callbacks
     // Very bloated, indeed
-    static void OnOutputGeometry(void*, wl_output*, int32_t, int32_t, int32_t, int32_t, int32_t, const char*, const char*, int32_t) {}
+    static void OnOutputGeometry(void*, wl_output* output, int32_t, int32_t, int32_t, int32_t, int32_t, const char*, const char*, int32_t transform)
+    {
+        auto it = monitors.find(output);
+        ASSERT(it != monitors.end(), "Error: OnOutputGeometry called on unknown monitor");
+        switch (transform)
+        {
+        case WL_OUTPUT_TRANSFORM_NORMAL:
+        case WL_OUTPUT_TRANSFORM_FLIPPED: it->second.rotation = 0; break;
+
+        case WL_OUTPUT_TRANSFORM_90:
+        case WL_OUTPUT_TRANSFORM_FLIPPED_90: it->second.rotation = 90; break;
+
+        case WL_OUTPUT_TRANSFORM_180:
+        case WL_OUTPUT_TRANSFORM_FLIPPED_180: it->second.rotation = 180; break;
+
+        case WL_OUTPUT_TRANSFORM_270:
+        case WL_OUTPUT_TRANSFORM_FLIPPED_270: it->second.rotation = 270; break;
+        }
+    }
     static void OnOutputMode(void*, wl_output* output, uint32_t, int32_t width, int32_t height, int32_t)
     {
         auto it = monitors.find(output);
@@ -211,7 +229,7 @@ namespace Wayland
         if (strcmp(interface, "wl_output") == 0)
         {
             wl_output* output = (wl_output*)wl_registry_bind(registry, name, &wl_output_interface, 4);
-            Monitor mon = Monitor{"", name, 0, 0, 0, nullptr, (uint32_t)monitors.size()};
+            Monitor mon = Monitor{"", name, 0, 0, 0, 0, nullptr, (uint32_t)monitors.size()};
             monitors.emplace(output, mon);
 
             LOG("Wayland: Register <pending> at ID " << mon.ID);

--- a/src/Wayland.h
+++ b/src/Wayland.h
@@ -13,6 +13,7 @@ namespace Wayland
         int32_t width;
         int32_t height;
         int32_t scale; // TODO: Handle fractional scaling
+        uint32_t rotation;
         zext_workspace_group_handle_v1* workspaceGroup;
         // The Gdk monitor index. This is only a hacky approximation, since there is no way to get the wl_output from a GdkMonitor
         uint32_t ID;

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -246,7 +246,16 @@ int Window::GetWidth() const
 
     const Wayland::Monitor* mon = Wayland::FindMonitorByName(m_MonitorName);
     ASSERT(mon, "Window: Couldn't find monitor");
-    return mon->width / mon->scale;
+
+    int viewedWidth = mon->width;
+
+    // A 90/270 rotation should use the height for the viewed width
+    switch (mon->rotation)
+    {
+    case 90:
+    case 270: viewedWidth = mon->height; break;
+    }
+    return viewedWidth / mon->scale;
 }
 
 int Window::GetHeight() const
@@ -257,7 +266,16 @@ int Window::GetHeight() const
 
     const Wayland::Monitor* mon = Wayland::FindMonitorByName(m_MonitorName);
     ASSERT(mon, "Window: Couldn't find monitor");
-    return mon->height / mon->scale;
+
+    int viewedHeight = mon->height;
+
+    // A 90/270 rotation should use the width for the viewed height
+    switch (mon->rotation)
+    {
+    case 90:
+    case 270: viewedHeight = mon->width; break;
+    }
+    return viewedHeight / mon->scale;
 }
 
 void Window::MonitorAdded(GdkDisplay*, GdkMonitor*)


### PR DESCRIPTION
When using a rotated monitor, the width value is incorrect and most of the widgets are off screen (1080x1920 in the screenshots):

![image](https://github.com/scorpion-26/gBar/assets/927233/688dd172-1188-43ef-b6d7-67cd61c81db9)

Taking the transform into account (swapping width and height when 90/270° rotation is applied) displays correctly:

![image](https://github.com/scorpion-26/gBar/assets/927233/5e8a2a4d-e7d7-425d-b89a-78e2afead677)
