### PR TITLE
Add configurable gpu thermal zone

### DIFF
--- a/data/config
+++ b/data/config
@@ -32,6 +32,13 @@ WidgetsRight: [Tray, Packages, Audio, Bluetooth, Network, Disk, VRAM, GPU, RAM, 
 # The CPU sensor to use
 CPUThermalZone: /sys/devices/pci0000:00/0000:00:18.3/hwmon/hwmon2/temp1_input
 
+# The card to poll when using AMDGPU. If you don't have an AMD card, you can skip this config.
+# Possible values can be found by querying /sys/class/drm
+DrmAmdCard: card0
+
+# Relative path to AMD gpu thermal sensor, appended after /sys/class/drm/<DrmAmdCard>
+AmdGPUThermalZone: /device/hwmon/hwmon1/temp1_input
+
 # The command to execute on suspend
 SuspendCommand: ~/.config/scripts/sys.sh suspend
 
@@ -159,10 +166,6 @@ NetworkAdapter: eno1
 
 # Disables the network widget when set to false
 NetworkWidget: true
-
-# The card to poll when using AMDGPU. If you don't have an AMD card, you can skip this config.
-# Possible values can be found by querying /sys/class/drm
-DrmAmdCard: card0
 
 # Use tooltips instead of sliders for the sensors
 SensorTooltips: false

--- a/module.nix
+++ b/module.nix
@@ -38,6 +38,11 @@ in {
                     default = "/sys/devices/pci0000:00/0000:00:18.3/hwmon/hwmon2/temp1_input";
                     description = "path to the cpu thermal sensor, probably something in /sys/device";
                 };
+                GPUThermalZone = mkOption {
+                    type = types.nullOr types.str;
+                    default = "/sys/class/drm/card0/device/hwmon/hwmon0/temp1_input";
+                    description = "path to the gpu thermal sensor, probably something in /sys/device";
+                };
                 SuspendCommand = mkOption {
                     type = types.str;
                     default = "systemctl suspend";

--- a/module.nix
+++ b/module.nix
@@ -38,10 +38,15 @@ in {
                     default = "/sys/devices/pci0000:00/0000:00:18.3/hwmon/hwmon2/temp1_input";
                     description = "path to the cpu thermal sensor, probably something in /sys/device";
                 };
-                GPUThermalZone = mkOption {
+                DrmAmdCard = mkOption {
                     type = types.nullOr types.str;
-                    default = "";
-                    description = "path to the gpu thermal sensor, probably something in /sys/device";
+                    default = "card0";
+                    description = "AMD card to be queried for various system usage and temperature metrics. This can be found in /sys/class/drm";
+                };
+                AmdGPUThermalZone = mkOption {
+                    type = types.nullOr types.str;
+                    default = "/device/hwmon/hwmon0/temp1_input";
+                    description = "Relative path to AMD gpu thermal sensor, appended after /sys/class/drm/<DrmAmdCard>";
                 };
                 SuspendCommand = mkOption {
                     type = types.str;

--- a/module.nix
+++ b/module.nix
@@ -45,7 +45,7 @@ in {
                 };
                 AmdGPUThermalZone = mkOption {
                     type = types.nullOr types.str;
-                    default = "/device/hwmon/hwmon0/temp1_input";
+                    default = "/device/hwmon/hwmon1/temp1_input";
                     description = "Relative path to AMD gpu thermal sensor, appended after /sys/class/drm/<DrmAmdCard>";
                 };
                 SuspendCommand = mkOption {

--- a/module.nix
+++ b/module.nix
@@ -40,7 +40,7 @@ in {
                 };
                 GPUThermalZone = mkOption {
                     type = types.nullOr types.str;
-                    default = "/sys/class/drm/card0/device/hwmon/hwmon0/temp1_input";
+                    default = "";
                     description = "path to the gpu thermal sensor, probably something in /sys/device";
                 };
                 SuspendCommand = mkOption {

--- a/src/AMDGPU.h
+++ b/src/AMDGPU.h
@@ -10,7 +10,6 @@ namespace AMDGPU
     static const char* utilizationFile = "/device/gpu_busy_percent";
     static const char* vramTotalFile = "/device/mem_info_vram_total";
     static const char* vramUsedFile = "/device/mem_info_vram_used";
-    // TODO: Make this configurable
     static const char* tempFile = "/device/hwmon/hwmon0/temp1_input";
 
     inline void Init()
@@ -40,13 +39,20 @@ namespace AMDGPU
 
     inline uint32_t GetTemperature()
     {
-        if (!RuntimeConfig::Get().hasAMD)
+        if (!RuntimeConfig::Get().hasAMD && Config::Get().gpuThermalZone.empty())
         {
             LOG("Error: Called AMD GetTemperature, but AMD GPU wasn't found!");
             return {};
         }
+        std::ifstream file;
 
-        std::ifstream file(drmCardPrefix + Config::Get().drmAmdCard + tempFile);
+        if (Config::Get().gpuThermalZone.empty()) 
+        {
+          file.open(Config::Get().gpuThermalZone);
+        } else {
+          file.open(drmCardPrefix + Config::Get().drmAmdCard + tempFile);
+        }
+
         std::string line;
         std::getline(file, line);
         return atoi(line.c_str()) / 1000;

--- a/src/AMDGPU.h
+++ b/src/AMDGPU.h
@@ -11,7 +11,7 @@ namespace AMDGPU
     static const char* vramTotalFile = "/device/mem_info_vram_total";
     static const char* vramUsedFile = "/device/mem_info_vram_used";
     // TODO: Make this configurable
-    static const char* tempFile = "/sys/class/drm/card0/device/hwmon/hwmon1/temp1_input";
+    static const char* tempFile = "/device/hwmon/hwmon0/temp1_input";
 
     inline void Init()
     {

--- a/src/AMDGPU.h
+++ b/src/AMDGPU.h
@@ -10,7 +10,6 @@ namespace AMDGPU
     static const char* utilizationFile = "/device/gpu_busy_percent";
     static const char* vramTotalFile = "/device/mem_info_vram_total";
     static const char* vramUsedFile = "/device/mem_info_vram_used";
-    static const char* tempFile = "/device/hwmon/hwmon0/temp1_input";
 
     inline void Init()
     {
@@ -39,19 +38,13 @@ namespace AMDGPU
 
     inline uint32_t GetTemperature()
     {
-        if (!RuntimeConfig::Get().hasAMD && Config::Get().gpuThermalZone.empty())
+        if (!RuntimeConfig::Get().hasAMD)
         {
             LOG("Error: Called AMD GetTemperature, but AMD GPU wasn't found!");
             return {};
         }
-        std::ifstream file;
 
-        if (Config::Get().gpuThermalZone.empty()) 
-        {
-          file.open(Config::Get().gpuThermalZone);
-        } else {
-          file.open(drmCardPrefix + Config::Get().drmAmdCard + tempFile);
-        }
+        std::ifstream file(drmCardPrefix + Config::Get().drmAmdCard + Config::Get().amdGpuThermalZone);
 
         std::string line;
         std::getline(file, line);

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -252,6 +252,7 @@ void Config::Load(const std::string& overrideConfigLocation)
         AddConfigVar("WidgetsRight", config.widgetsRight, lineView, foundProperty);
 
         AddConfigVar("CPUThermalZone", config.cpuThermalZone, lineView, foundProperty);
+        AddConfigVar("GPUThermalZone", config.gpuThermalZone, lineView, foundProperty);
         AddConfigVar("NetworkAdapter", config.networkAdapter, lineView, foundProperty);
         AddConfigVar("DrmAmdCard", config.drmAmdCard, lineView, foundProperty);
         AddConfigVar("SuspendCommand", config.suspendCommand, lineView, foundProperty);

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -252,7 +252,7 @@ void Config::Load(const std::string& overrideConfigLocation)
         AddConfigVar("WidgetsRight", config.widgetsRight, lineView, foundProperty);
 
         AddConfigVar("CPUThermalZone", config.cpuThermalZone, lineView, foundProperty);
-        AddConfigVar("GPUThermalZone", config.gpuThermalZone, lineView, foundProperty);
+        AddConfigVar("AmdGPUThermalZone", config.amdGpuThermalZone, lineView, foundProperty);
         AddConfigVar("NetworkAdapter", config.networkAdapter, lineView, foundProperty);
         AddConfigVar("DrmAmdCard", config.drmAmdCard, lineView, foundProperty);
         AddConfigVar("SuspendCommand", config.suspendCommand, lineView, foundProperty);

--- a/src/Config.h
+++ b/src/Config.h
@@ -14,7 +14,7 @@ public:
                                              "VRAM", "GPU",      "RAM",   "CPU",       "Battery", "Power"};
 
     std::string cpuThermalZone = "";     // idk, no standard way of doing this.
-    std::string gpuThermalZone = "";
+    std::string amdGpuThermalZone = "/device/hwmon/hwmon0/temp1_input";
     std::string networkAdapter = "eno1"; // Is this standard?
     std::string drmAmdCard = "card0";    // The card to poll in AMDGPU.
     std::string suspendCommand = "systemctl suspend";

--- a/src/Config.h
+++ b/src/Config.h
@@ -14,7 +14,7 @@ public:
                                              "VRAM", "GPU",      "RAM",   "CPU",       "Battery", "Power"};
 
     std::string cpuThermalZone = "";     // idk, no standard way of doing this.
-    std::string amdGpuThermalZone = "/device/hwmon/hwmon0/temp1_input";
+    std::string amdGpuThermalZone = "/device/hwmon/hwmon1/temp1_input";
     std::string networkAdapter = "eno1"; // Is this standard?
     std::string drmAmdCard = "card0";    // The card to poll in AMDGPU.
     std::string suspendCommand = "systemctl suspend";

--- a/src/Config.h
+++ b/src/Config.h
@@ -14,6 +14,7 @@ public:
                                              "VRAM", "GPU",      "RAM",   "CPU",       "Battery", "Power"};
 
     std::string cpuThermalZone = "";     // idk, no standard way of doing this.
+    std::string gpuThermalZone = "";
     std::string networkAdapter = "eno1"; // Is this standard?
     std::string drmAmdCard = "card0";    // The card to poll in AMDGPU.
     std::string suspendCommand = "systemctl suspend";


### PR DESCRIPTION
I noticed a bug where the `tempFile` was the entire path (instead of just the subpath) leading to some issues. So I fixed that and also added an option to set the entire path via the config since I'm not sure if the path will be the same for everyone.

If the path: `device/hwmon/hwmon0/temp1_input` won't change across machines then the configuration addition probably isn't needed since you can configure the card.